### PR TITLE
Fix URL

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -16,7 +16,7 @@ const OFFLINE_RESOURCES = [
                           '/404.html',
                           '/print.html',
                           '/assets/logo.svg',
-                          '/assets/js/plotly-basic.min.js',
+                          '/assets/js/external/plotly-basic.min.js',
                           '/dist/',
                           '/dist/main.css',
                           '/dist/notFound.css',


### PR DESCRIPTION
Wrong URL for service worker crash would cause the service worker not being able to update.