### PR TITLE
Remove dist folder caching

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -17,7 +17,6 @@ const OFFLINE_RESOURCES = [
                           '/print.html',
                           '/assets/logo.svg',
                           '/assets/js/external/plotly-basic.min.js',
-                          '/dist/',
                           '/dist/main.css',
                           '/dist/notFound.css',
                           '/dist/main.bundle.js',


### PR DESCRIPTION
Wrong URL for service worker crash would cause the service worker not being able to update.